### PR TITLE
Fix 'Invalid database query parameter value' exception when restoring course with 'Any cohort' restriction

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -212,7 +212,7 @@ class condition extends \core_availability\condition {
             if ($DB->record_exists('cohort', ['id' => $this->cohortid]) &&
                     cohort_get_cohort($this->cohortid, \context_course::instance($courseid))) {
                 $returnvalue = true;
-            } else if ($this->cohortid == 0 && !empty(cohort_get_cohorts(\context_course::instance($courseid)))) {
+            } else if ($this->cohortid == 0 && !empty(cohort_get_cohorts(\context_course::instance($courseid)->id))) {
                 // The setting was set to any cohort and cohorts have not been deleted in the meantime.
                 // Import the activity with the condition.
                 $returnvalue = true;
@@ -223,7 +223,7 @@ class condition extends \core_availability\condition {
         } else {
             // We are not on the same instance.
             // We have to check if the setting was set to any cohort and cohorts exist on the new instance.
-            if ($this->cohortid == 0 && !empty(cohort_get_cohorts(\context_course::instance($courseid)))) {
+            if ($this->cohortid == 0 && !empty(cohort_get_cohorts(\context_course::instance($courseid)->id))) {
                 $returnvalue = true;
             } else {
                 // Availability was not set to any cohort, so do not include.


### PR DESCRIPTION
> Invalid database query parameter value: Objects are are not allowed: core\context\course

This is because `cohort_get_cohorts()` requires a context ID, not an object, and passes it as a condition to `$DB->count_records()`. (It is inconsistent with `cohort_get_cohort()` which requires an object!)

Tested in Moodle 4.4.1.